### PR TITLE
Add basic Node tests and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '20'
+    - run: npm test

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ If OpenAI updates its theme tokens you normally don’t need to touch the script
 ## Contributing
 
 Pull requests are welcome! Please lint with `eslint` and test in both light & dark themes before submitting. Refer to GitHub’s guidelines for userscript READMEs for formatting conventions.
+## Running tests
+
+Run the built-in Node test suite:
+
+```bash
+npm test
+```
+
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "codex-gitlab-greasy-script",
+  "version": "1.0.0",
+  "description": "Testing utilities for Codex Gitlab Greasy Script",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,13 @@
+function setLoading(state, elements, loadingEl) {
+  loadingEl.classList.toggle('visible', state);
+  elements.forEach(el => {
+    el.disabled = state;
+  });
+}
+
+function validate(titleEl, branchEl, textAreaEl, sendBtnEl) {
+  const ok = titleEl.value.trim() && branchEl.value.trim() && textAreaEl.value.trim();
+  sendBtnEl.disabled = !ok;
+}
+
+module.exports = { setLoading, validate };

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,49 @@
+const { test } = require("node:test");
+const assert = require('assert');
+const { setLoading, validate } = require('../src/helpers');
+
+function createEl() {
+  return {
+    disabled: false,
+    value: '',
+    classList: {
+      _set: new Set(),
+      toggle(name, flag) {
+        if(flag === undefined) {
+          if(this._set.has(name)) this._set.delete(name); else this._set.add(name);
+        } else {
+          if(flag) this._set.add(name); else this._set.delete(name);
+        }
+      },
+      contains(name) { return this._set.has(name); }
+    }
+  };
+}
+
+test('setLoading toggles visibility and disables fields', () => {
+  const loading = createEl();
+  const a = createEl();
+  const b = createEl();
+  setLoading(true, [a, b], loading);
+  assert(loading.classList.contains('visible'));
+  assert(a.disabled && b.disabled);
+  setLoading(false, [a, b], loading);
+  assert(!loading.classList.contains('visible'));
+  assert(!a.disabled && !b.disabled);
+});
+
+test('validate enables send button when all fields have text', () => {
+  const title = createEl();
+  const branch = createEl();
+  const textArea = createEl();
+  const sendBtn = createEl();
+
+  validate(title, branch, textArea, sendBtn);
+  assert(sendBtn.disabled, 'should disable when empty');
+
+  title.value = 'a';
+  branch.value = 'b';
+  textArea.value = 'c';
+  validate(title, branch, textArea, sendBtn);
+  assert.strictEqual(sendBtn.disabled, false);
+});


### PR DESCRIPTION
## Summary
- add helpers module with small DOM logic functions
- test helper functions with Node's built-in test runner
- document how to run the tests
- run `npm test` on push via GitHub Actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d83592ec0832b8453e98214019e8b