### PR TITLE
Fix FAB disappearance

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -8,6 +8,7 @@
 // @grant        GM_xmlhttpRequest
 // @grant        GM_getValue
 // @grant        GM_setValue
+// @run-at       document-idle
 // ==/UserScript==
 
 (() => {
@@ -111,7 +112,20 @@
       <ellipse cx="583.762" cy="585.298" rx="100.237" ry="100.203" fill="#0ABE98"/>
     </svg>`;
   fab.title = 'Send MR data…';
-  document.body.append(fab);
+
+  const ensureFab = () => {
+    if (document.body && !document.body.contains(fab)) {
+      document.body.append(fab);
+    }
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', ensureFab);
+  } else {
+    ensureFab();
+  }
+
+  new MutationObserver(ensureFab).observe(document, {childList: true, subtree: true});
 
 
   /* ---------------- OVERLAY/MODAL (built once) ---------------- */

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,9 +5,16 @@ function setLoading(state, elements, loadingEl) {
   });
 }
 
+function ensureFab(fab, doc = document) {
+  if (!doc.body) return;
+  if (!doc.body.contains(fab)) {
+    doc.body.appendChild(fab);
+  }
+}
+
 function validate(titleEl, branchEl, textAreaEl, sendBtnEl) {
   const ok = titleEl.value.trim() && branchEl.value.trim() && textAreaEl.value.trim();
   sendBtnEl.disabled = !ok;
 }
 
-module.exports = { setLoading, validate };
+module.exports = { setLoading, validate, ensureFab };

--- a/test/ensureFab.test.js
+++ b/test/ensureFab.test.js
@@ -1,0 +1,26 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const { ensureFab } = require('../src/helpers');
+
+function createDoc() {
+  const body = {
+    children: [],
+    appendChild(el) { this.children.push(el); },
+    removeChild(el) { this.children = this.children.filter(c => c !== el); },
+    contains(el) { return this.children.includes(el); }
+  };
+  return {
+    body,
+    createElement() { return {}; }
+  };
+}
+
+test('ensureFab reattaches button when missing', () => {
+  const doc = createDoc();
+  const btn = doc.createElement('button');
+  ensureFab(btn, doc);
+  assert(doc.body.contains(btn));
+  doc.body.removeChild(btn);
+  ensureFab(btn, doc);
+  assert(doc.body.contains(btn));
+});


### PR DESCRIPTION
## Summary
- keep floating FAB visible by enforcing insertion on DOM ready and mutations
- expose `ensureFab` helper
- test new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e7f50c488832b93b5907ab27c3357