### PR TITLE
Fix missing fab on SPA navigation

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -119,6 +119,24 @@
     }
   };
 
+  const watchNavigation = () => {
+    const { history } = window;
+    const origPush = history.pushState;
+    const origReplace = history.replaceState;
+    const call = () => ensureFab();
+    history.pushState = function (...args) {
+      const r = origPush.apply(this, args);
+      call();
+      return r;
+    };
+    history.replaceState = function (...args) {
+      const r = origReplace.apply(this, args);
+      call();
+      return r;
+    };
+    window.addEventListener('popstate', call);
+  };
+
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', ensureFab);
   } else {
@@ -126,6 +144,7 @@
   }
 
   new MutationObserver(ensureFab).observe(document, {childList: true, subtree: true});
+  watchNavigation();
 
 
   /* ---------------- OVERLAY/MODAL (built once) ---------------- */

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -17,4 +17,22 @@ function validate(titleEl, branchEl, textAreaEl, sendBtnEl) {
   sendBtnEl.disabled = !ok;
 }
 
-module.exports = { setLoading, validate, ensureFab };
+function watchNavigation(callback, win = window) {
+  const { history } = win;
+  const origPush = history.pushState;
+  const origReplace = history.replaceState;
+  const invoke = () => callback();
+  history.pushState = function (...args) {
+    const r = origPush.apply(this, args);
+    invoke();
+    return r;
+  };
+  history.replaceState = function (...args) {
+    const r = origReplace.apply(this, args);
+    invoke();
+    return r;
+  };
+  win.addEventListener('popstate', invoke);
+}
+
+module.exports = { setLoading, validate, ensureFab, watchNavigation };

--- a/test/watchNavigation.test.js
+++ b/test/watchNavigation.test.js
@@ -1,0 +1,31 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const { watchNavigation } = require('../src/helpers');
+
+function createWindow() {
+  const listeners = {};
+  return {
+    history: {
+      pushState: function(){},
+      replaceState: function(){},
+    },
+    addEventListener(event, fn) { listeners[event] = fn; },
+    dispatchEvent(event) { if(listeners[event.type]) listeners[event.type](event); },
+    _listeners: listeners
+  };
+}
+
+test('watchNavigation triggers callback on history changes', () => {
+  const win = createWindow();
+  let called = 0;
+  watchNavigation(() => called++, win);
+
+  win.history.pushState({}, '', '/foo');
+  assert.strictEqual(called, 1);
+
+  win.history.replaceState({}, '', '/bar');
+  assert.strictEqual(called, 2);
+
+  win.dispatchEvent({ type: 'popstate' });
+  assert.strictEqual(called, 3);
+});


### PR DESCRIPTION
## Summary
- ensure floating button is restored when navigating between Codex pages
- expose `watchNavigation` helper and test it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e820dec30832bb44e8702cc29c380