### PR TITLE
Fix token hint link styling

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -84,8 +84,16 @@
     #codex-toast.success{background:var(--codex-bg-accent)}
     #codex-toast.error{background:#d93025}
 
-    #codex-token-hint{color:#fff;font-size:12px;text-decoration:none}
-    #codex-token-hint:hover{text-decoration:underline}
+    #codex-token-hint,
+    #codex-github-token-hint {
+      color:#fff;
+      font-size:12px;
+      text-decoration:none;
+    }
+    #codex-token-hint:hover,
+    #codex-github-token-hint:hover {
+      text-decoration:underline;
+    }
   `);
 
   /* ---------------- HELPERS ---------------- */


### PR DESCRIPTION
## Summary
- unify styles for GitLab and GitHub token hint links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e8e7f2774832bbdf76e7799b38a17